### PR TITLE
Change s3_log_folder to remote_base_log_folder

### DIFF
--- a/templates/airflow.cfg.j2
+++ b/templates/airflow.cfg.j2
@@ -11,7 +11,7 @@ base_log_folder = {{ airflow_base_log_folder }}
 
 # An S3 location can be provided for log backups
 # For S3, use the full URL to the base folder (starting with "s3://...")
-s3_log_folder = {{ airflow_s3_log_folder }}
+remote_base_log_folder = {{ airflow_s3_log_folder }}
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor


### PR DESCRIPTION
`s3_log_folder` is now deprecated and causes warnings when running airflow.  I've left the variable name intact so that backward compatibility is maintained.
